### PR TITLE
Fix/page break issues

### DIFF
--- a/public/styles/pdf-export.css
+++ b/public/styles/pdf-export.css
@@ -20,7 +20,7 @@ html, body {
   user-select: text;
 }
 
-/* Page break control */
+/* Page break control - prevent elements from being split across pages */
 .prose h1, .prose h2, .prose h3, .prose h4, .prose h5, .prose h6,
 .prose p, .prose ul, .prose ol, .prose li,
 .prose table, .prose tr, .prose td, .prose th,
@@ -34,18 +34,6 @@ html, body {
 .prose p {
   orphans: 3;
   widows: 3;
-}
-
-/* Force page breaks before major sections, but not for the first h1 */
-.prose h1:not(:first-child) {
-  page-break-before: always;
-  break-before: page;
-}
-
-/* Avoid page breaks after headings */
-.prose h1, .prose h2, .prose h3, .prose h4, .prose h5, .prose h6 {
-  page-break-after: avoid;
-  break-after: avoid;
 }
 
 /* Typography */

--- a/public/styles/pdf-export.css
+++ b/public/styles/pdf-export.css
@@ -20,6 +20,34 @@ html, body {
   user-select: text;
 }
 
+/* Page break control */
+.prose h1, .prose h2, .prose h3, .prose h4, .prose h5, .prose h6,
+.prose p, .prose ul, .prose ol, .prose li,
+.prose table, .prose tr, .prose td, .prose th,
+.prose pre, .prose code, .prose blockquote,
+.prose img, .prose figure, .prose figcaption {
+  page-break-inside: avoid;
+  break-inside: avoid;
+}
+
+/* Prevent orphans and widows */
+.prose p {
+  orphans: 3;
+  widows: 3;
+}
+
+/* Force page breaks before major sections, but not for the first h1 */
+.prose h1:not(:first-child) {
+  page-break-before: always;
+  break-before: page;
+}
+
+/* Avoid page breaks after headings */
+.prose h1, .prose h2, .prose h3, .prose h4, .prose h5, .prose h6 {
+  page-break-after: avoid;
+  break-after: avoid;
+}
+
 /* Typography */
 .prose h1, .prose h2, .prose h3, .prose h4, .prose h5, .prose h6 {
   margin-top: 1.5em;
@@ -251,4 +279,13 @@ html, body {
 .prose ul[data-type="taskList"] li::before {
   content: '';
   display: none;
+}
+
+.prose > h1:first-child,
+.prose > h2:first-child,
+.prose > h3:first-child,
+.prose > h4:first-child,
+.prose > h5:first-child,
+.prose > h6:first-child {
+  margin-top: 0 !important;
 }

--- a/src/utils/pdfExport.client.ts
+++ b/src/utils/pdfExport.client.ts
@@ -39,7 +39,7 @@ export async function downloadFile(htmlString: string, fileName: string) {
     console.log('Final HTML Structure:', htmlWithStyles)
 
     const opt = {
-      margin: [0, 10, 10, 10],
+      margin: [10, 10, 10, 10],
       filename: fileName,
       image: { type: 'jpeg', quality: 0.95 },
       html2canvas: { 


### PR DESCRIPTION
When elements overlap between page breaks it creates unavoidable rendering issues with the html2pdf library. This creates a fix where if an element is going to overlap it places it onto a new page. 