### PR TITLE
	modified:   src/components/tiptap-templates/simple/simple-editor.scss

### DIFF
--- a/src/components/tiptap-templates/simple/simple-editor.scss
+++ b/src/components/tiptap-templates/simple/simple-editor.scss
@@ -69,16 +69,17 @@ body {
 }
 
 .simple-editor-content {
-  max-width: 640px;
-  width: 100%;
-  margin: 0 auto;
-  min-height: 100%;
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
 }
 
 .simple-editor-content .tiptap.ProseMirror {
   padding: 3rem 3rem;
   min-height: 100%;
+  padding-bottom: 10rem; // or any large value
 }
+
 
 /* Add styles for the editor container */
 .simple-editor-container {

--- a/src/components/tiptap-templates/simple/simple-editor.tsx
+++ b/src/components/tiptap-templates/simple/simple-editor.tsx
@@ -336,12 +336,24 @@ export function SimpleEditor({
                     )}
                 </Toolbar>
 
-                <div className="content-wrapper">
-                    <EditorContent
-                        editor={editor}
-                        role="presentation"
-                        className="simple-editor-content"
-                    />
+                <div
+                  className="content-wrapper"
+                  style={{ cursor: 'text' }}
+                  onMouseDown={e => {
+                    if (e.target === e.currentTarget && editor) {
+                      setTimeout(() => {
+                        // Always move caret to end, regardless of focus state
+                        editor.commands.focus();
+                        editor.commands.setTextSelection(editor.state.doc.content.size);
+                      }, 0);
+                    }
+                  }}
+                >
+                  <EditorContent
+                    editor={editor}
+                    role="presentation"
+                    className="simple-editor-content"
+                  />
                 </div>
             </div>
         </EditorContext.Provider>


### PR DESCRIPTION
The whitespace inside the text editor now can get clicked to send your mouse to the bottommost text.
Toolbar still is inside the editor border...
	modified:   src/components/tiptap-templates/simple/simple-editor.tsx