### PR TITLE
Live editing over Supabase Realtime

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,9 @@ DATABASE_URL=postgresql://USER:PASSWORD@HOST:PORT/DATABASE
 # SUPABASE_SERVICE_ROLE_KEY=
 # NEXT_PUBLIC_SUPABASE_URL=
 # NEXT_PUBLIC_SUPABASE_ANON_KEY=
+
+# ── Live editing (real-time collaboration) ──────────────────────────────────
+# Live editing runs over Supabase Realtime — no separate server needed. It uses
+# the SUPABASE vars above (NEXT_PUBLIC_SUPABASE_URL + NEXT_PUBLIC_SUPABASE_ANON_KEY),
+# so make sure both are set in the app's environment (local and on Vercel).
+# See docs/LIVE_EDITING_SUPABASE.md for the one-time Supabase setup.

--- a/docs/LIVE_EDITING_SUPABASE.md
+++ b/docs/LIVE_EDITING_SUPABASE.md
@@ -1,0 +1,80 @@
+# Live editing (real-time collaboration) via Supabase Realtime
+
+Live editing is powered by **Supabase Realtime** — the same Supabase project the
+app already uses. There is **no separate server** and **no extra cost**.
+
+- Client hook: `src/hooks/use-supabase-yjs-collaboration.ts`
+- Transport: **private** Supabase Realtime channels named `doc:<documentId>`
+
+When a channel can't be authorized, the editor shows
+**"Live editing: unavailable (closed)."** Private channels require two one-time
+setup steps below. After that it just works, including on Vercel.
+
+---
+
+## Part A — Connect Clerk to Supabase (Third-Party Auth)
+
+This makes Supabase trust your Clerk users and see them as `authenticated`, which
+is required to open a private channel. (The old JWT-template/secret method was
+deprecated by Supabase in April 2025 — don't use it.)
+
+Official guide (follow this if the dashboard UI differs from the steps below):
+https://clerk.com/docs/integrations/databases/supabase
+
+1. **Clerk dashboard** → your app → **Integrations** → enable **Supabase**.
+   - Clerk turns on the `role: "authenticated"` claim in session tokens and shows
+     you your **Clerk domain** (looks like `https://your-app.clerk.accounts.dev`).
+   - Copy that domain.
+2. **Supabase dashboard** → **Authentication** → **Sign In / Providers** →
+   **Third-Party Auth** → **Add provider** → **Clerk**.
+   - Paste the Clerk domain from step 1. Save.
+
+## Part B — Add the Realtime access rules
+
+1. **Supabase dashboard** → **SQL Editor** → **New query**.
+2. Paste the contents of [`supabase/live-editing-policies.sql`](../supabase/live-editing-policies.sql)
+   and click **Run**.
+
+This grants signed-in users access to the `doc:*` channels. (It does not yet
+enforce per-document permissions — see the note at the bottom of the SQL file.)
+
+## Part C — Environment variables
+
+Live editing uses the Supabase vars the app already needs. Confirm both are set
+**in Vercel** (Settings → Environment Variables) and locally in `.env`:
+
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+
+No new variables are required. If you had to add them in Vercel, **redeploy**
+(these are baked in at build time).
+
+---
+
+## Verify
+
+Open a document, then DevTools → Console.
+
+- **Working:** the status bar reads **"Live editing: connected."** Open the same
+  document in a second signed-in browser and confirm edits + cursors sync.
+- **Still closed:** look for a log line
+  `Supabase live editing channel failed: { ..., tokenSource, tokenClaims, restAuthStatus }`
+  - `tokenSource: "clerk-session-missing-authenticated-role"` → **Part A** isn't
+    active. Re-check the Clerk Supabase integration and the Supabase provider.
+  - `tokenSource: "clerk-session"` (role authenticated) but still closed →
+    **Part B** — the SQL policies didn't apply. Re-run the SQL.
+
+---
+
+## Emergency fallback (temporary, less secure)
+
+If Part A/B can't be completed in time and you need live editing working *now*,
+switch to public channels: in `src/hooks/use-supabase-yjs-collaboration.ts` set
+
+```ts
+const USE_PRIVATE_REALTIME = false
+```
+
+Public channels need no Clerk/RLS setup and work with just the anon key, but the
+edit stream can be joined by anyone with the app's public key who guesses a
+document id. Flip it back to `true` once Parts A/B are done.

--- a/src/components/sheet-editor.tsx
+++ b/src/components/sheet-editor.tsx
@@ -22,7 +22,7 @@ import { Button } from '~/components/ui/button'
 import { Badge } from '~/components/ui/badge'
 import { Card, CardContent } from '~/components/ui/card'
 import { Plus, Activity, Shield, Info, Undo, Redo } from 'lucide-react'
-import { useYjsCollaboration } from '~/hooks/use-yjs-collaboration'
+import { useSupabaseYjsCollaboration as useYjsCollaboration } from '~/hooks/use-supabase-yjs-collaboration'
 import * as Y from 'yjs'
 
 function getPermissionLabel(permission: 'view' | 'comment' | 'edit') {

--- a/src/components/tiptap-templates/simple/simple-editor.tsx
+++ b/src/components/tiptap-templates/simple/simple-editor.tsx
@@ -69,7 +69,7 @@ import { LinkIcon } from '@/components/tiptap-icons/link-icon'
 import { useMobile } from '~/hooks/use-mobile'
 import { useWindowSize } from '~/hooks/use-window-size'
 import { useCursorVisibility } from '~/hooks/use-cursor-visibility'
-import { useYjsCollaboration } from '~/hooks/use-yjs-collaboration'
+import { useSupabaseYjsCollaboration as useYjsCollaboration } from '~/hooks/use-supabase-yjs-collaboration'
 
 // --- Components ---
 import { ThemeToggle } from '~/components/tiptap-templates/simple/theme-toggle'

--- a/src/hooks/use-supabase-yjs-collaboration.ts
+++ b/src/hooks/use-supabase-yjs-collaboration.ts
@@ -253,46 +253,23 @@ function testBrowserRealtimeSocket() {
 }
 
 async function getSupabaseRealtimeToken(session: ClerkSession) {
-    const defaultToken = await session.getToken({ skipCache: true })
-    const defaultClaims = decodeJwtDebugClaims(defaultToken)
-
-    try {
-        const templateToken = await session.getToken({
-            template: 'supabase',
-            skipCache: true,
-        })
-        const templateClaims = decodeJwtDebugClaims(templateToken)
-
-        if (templateToken) {
-            return {
-                token: templateToken,
-                claims: templateClaims,
-                source: 'supabase-template',
-            }
-        }
-    } catch (error) {
-        console.warn(
-            `Supabase live editing token template unavailable: ${JSON.stringify(
-                getRealtimeErrorDebug(error)
-            )}`
-        )
-    }
-
-    if (defaultToken) {
-        return {
-            token: defaultToken,
-            claims: defaultClaims,
-            source:
-                defaultClaims?.role === 'authenticated'
-                    ? 'default'
-                    : 'default-missing-authenticated-role',
-        }
-    }
+    // With Supabase Third-Party Auth for Clerk enabled, the standard Clerk
+    // session token already carries `role: "authenticated"`, which is what
+    // Supabase Realtime needs to authorize a private channel. No JWT template
+    // is required (the legacy template approach was deprecated in April 2025).
+    // The `source` label is kept for debugging: if it ever reports
+    // `missing-authenticated-role`, the Clerk↔Supabase integration isn't active.
+    const token = await session.getToken({ skipCache: true })
+    const claims = decodeJwtDebugClaims(token)
 
     return {
-        token: defaultToken,
-        claims: defaultClaims,
-        source: 'missing-token',
+        token,
+        claims,
+        source: token
+            ? claims?.role === 'authenticated'
+                ? 'clerk-session'
+                : 'clerk-session-missing-authenticated-role'
+            : 'missing-token',
     }
 }
 

--- a/supabase/live-editing-policies.sql
+++ b/supabase/live-editing-policies.sql
@@ -1,0 +1,46 @@
+-- ============================================================================
+-- Live editing — Supabase Realtime Authorization policies
+-- ============================================================================
+-- Live editing uses PRIVATE Supabase Realtime channels named `doc:<id>`
+-- (see src/hooks/use-supabase-yjs-collaboration.ts). Private channels are gated
+-- by Row Level Security on the `realtime.messages` table. Without the policies
+-- below, Supabase closes the channel and the editor shows
+-- "Live editing: unavailable (closed)".
+--
+-- Run this ONCE in the Supabase dashboard → SQL Editor → New query → Run.
+-- Prerequisite: Clerk must be configured as a Supabase Third-Party Auth provider
+-- so signed-in users arrive with role = authenticated
+-- (see docs/LIVE_EDITING_SUPABASE.md).
+-- ----------------------------------------------------------------------------
+
+-- RLS is already enabled on realtime.messages when Realtime Authorization is
+-- used; this line is a harmless no-op if it is already on.
+alter table realtime.messages enable row level security;
+
+-- Allow any signed-in user to RECEIVE broadcast/presence on doc:* channels.
+drop policy if exists "live_editing_read_doc_channels" on realtime.messages;
+create policy "live_editing_read_doc_channels"
+on realtime.messages
+for select
+to authenticated
+using (
+    extension in ('broadcast', 'presence')
+    and realtime.topic() like 'doc:%'
+);
+
+-- Allow any signed-in user to SEND broadcast/presence on doc:* channels.
+drop policy if exists "live_editing_write_doc_channels" on realtime.messages;
+create policy "live_editing_write_doc_channels"
+on realtime.messages
+for insert
+to authenticated
+with check (
+    extension in ('broadcast', 'presence')
+    and realtime.topic() like 'doc:%'
+);
+
+-- NOTE: These policies let ANY signed-in user join ANY document's channel. That
+-- is a big improvement over public channels (which require no login at all), but
+-- it does not yet enforce per-document permissions. To tighten later, parse the
+-- document id out of realtime.topic() (e.g. split_part(realtime.topic(), ':', 2))
+-- and check it against the app's file/permission tables inside the USING/CHECK.


### PR DESCRIPTION
## What this does
Switches real-time live editing to run over **Supabase Realtime** (private channels) instead of the Hocuspocus WebSocket server, which required a separate always-on host. This uses the existing Supabase project — no new service, no extra cost.

## Why
On `main`, the editors connect to a Hocuspocus server at `ws://127.0.0.1:1234`, which isn't deployed — so live editing showed **"unavailable (closed)"** in production.

## Changes
- `sheet-editor` + `simple-editor` now use `useSupabaseYjsCollaboration`
- Simplified the realtime token to the native Clerk session (Supabase Third-Party Auth); dropped the deprecated JWT-template attempt
- `supabase/live-editing-policies.sql` — Realtime Authorization RLS for `doc:*` channels
- `docs/LIVE_EDITING_SUPABASE.md` — setup guide; documented env in `.env.example`

## Supabase setup (already applied)
- ✅ Clerk configured as a Supabase Third-Party Auth provider
- ✅ Realtime RLS policies applied

## Notes
- Policies currently allow any signed-in user onto any `doc:*` channel; per-document permission checks are a documented follow-up.
- Durability is unaffected — documents load/save via the DB autosave path regardless of realtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)