### PR TITLE
Fix: live editing stuck on 'connecting' (normalize SUPABASE_URL)

### DIFF
--- a/src/hooks/use-supabase-yjs-collaboration.ts
+++ b/src/hooks/use-supabase-yjs-collaboration.ts
@@ -54,6 +54,15 @@ const HEARTBEAT_FAILURES_BEFORE_RECONNECT = 3
 const SEND_FAILURES_BEFORE_RECONNECT = 2
 const USE_PRIVATE_REALTIME = true
 
+// NEXT_PUBLIC_SUPABASE_URL is sometimes configured with a trailing `/rest/v1`
+// (the PostgREST base). supabase-js needs the bare project URL — otherwise the
+// realtime socket URL becomes `.../rest/v1/realtime/v1/websocket` and can never
+// connect (you get "connecting" forever). Strip it so the value can't be
+// misconfigured, mirroring what the keep-alive workflow already does.
+const SUPABASE_URL = (process.env.NEXT_PUBLIC_SUPABASE_URL ?? '')
+    .replace(/\/rest\/v1\/?$/, '')
+    .replace(/\/+$/, '')
+
 function bytesToBase64(bytes: Uint8Array) {
     let binary = ''
     for (let index = 0; index < bytes.length; index += 1) {
@@ -381,7 +390,7 @@ export function useSupabaseYjsCollaboration({
             if (!realtimeSessionKey) return null
 
             return createClient(
-                process.env.NEXT_PUBLIC_SUPABASE_URL!,
+                SUPABASE_URL,
                 process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
                 {
                     accessToken: async () =>
@@ -397,7 +406,7 @@ export function useSupabaseYjsCollaboration({
         }
 
         return createClient(
-            process.env.NEXT_PUBLIC_SUPABASE_URL!,
+            SUPABASE_URL,
             process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
             {
                 auth: {


### PR DESCRIPTION
## Problem
After #116, live editing was stuck on **"connecting"** and never connected. The realtime WebSocket URL came out as:

`wss://<ref>.supabase.co/rest/v1/realtime/v1/websocket`

The extra `/rest/v1` makes the socket unreachable (transport failure, code 1006).

## Cause
`NEXT_PUBLIC_SUPABASE_URL` is configured with a trailing `/rest/v1`. `supabase-js` appends `/realtime/v1/websocket` to it, producing the malformed URL. (The keep-alive workflow already normalizes this same quirk.)

## Fix
Strip a trailing `/rest/v1` (and trailing slashes) from the URL before creating the Supabase client, so realtime connects regardless of how the env var is set. Applies to both the private and public client paths.

## After merging
Redeploy will pick it up; the editor status should go "connecting" → "connected". If a secondary auth error appears in the console afterward, that's the next thing to check (Clerk JWT verification), tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)