### PR TITLE
Fix: edits vanish on reopen — decouple file save/load from live editing

### DIFF
--- a/src/app/pages/[pageId]/page.tsx
+++ b/src/app/pages/[pageId]/page.tsx
@@ -12,6 +12,18 @@ import { api } from '~/trpc/react'
 
 type Permission = 'view' | 'comment' | 'edit'
 
+// Live editing (realtime collaboration) is temporarily OFF. Its content seeding
+// was gated on the realtime connection succeeding: the editor mounts bound to an
+// empty Yjs doc and only injects the saved content once the realtime channel
+// connects and this client is elected leader. While realtime is flaky/broken,
+// that seed runs late or never, so the editor can load blank/stale content and
+// the debounced auto-save then persists it OVER the real edit — which is why
+// edits vanish "sometimes" on reopen. With this off, files load and save
+// directly from the database (deterministic). Re-enable only once realtime is
+// verified working AND seeding no longer gates content. See
+// docs/LIVE_EDITING_SUPABASE.md.
+const LIVE_EDITING_ENABLED = false
+
 export default function PageView() {
     const params = useParams()
     const router = useRouter()
@@ -410,7 +422,9 @@ export default function PageView() {
                 <SimpleEditor
                     initialContent={content}
                     readOnly={isReadOnly}
-                    realtimeDocumentId={pageId}
+                    realtimeDocumentId={
+                        LIVE_EDITING_ENABLED ? pageId : undefined
+                    }
                     permission={userPermission ?? 'view'}
                     onUpdate={handleContentChange}
                 />

--- a/src/app/sheets/[sheetId]/page.tsx
+++ b/src/app/sheets/[sheetId]/page.tsx
@@ -13,6 +13,13 @@ import { toast } from '~/hooks/use-toast'
 
 type PermissionType = 'view' | 'comment' | 'edit'
 
+// Live editing (realtime collaboration) is temporarily OFF while the Supabase
+// realtime connection is being fixed. Keeping it on entangles saving/loading
+// with a flaky connection and risks edits being overwritten. With this off,
+// sheets load and save directly from the database. See the note in
+// src/app/pages/[pageId]/page.tsx and docs/LIVE_EDITING_SUPABASE.md.
+const LIVE_EDITING_ENABLED = false
+
 export default function SheetPage() {
     const params = useParams()
     const sheetId = Number(params.sheetId as string)
@@ -228,7 +235,9 @@ export default function SheetPage() {
                     sheetId={sheetId}
                     sheetName={sheet.name}
                     readOnly={isReadOnly}
-                    realtimeDocumentId={sheetId}
+                    realtimeDocumentId={
+                        LIVE_EDITING_ENABLED ? sheetId : undefined
+                    }
                     permission={userPermission ?? 'view'}
                     syncMetadata={
                         syncMetadata


### PR DESCRIPTION
## The bug
Editing a document or spreadsheet, then refreshing or reopening it, could show the edit gone — sometimes even after "saved" appeared. The DB copy stays intact (other users and version history show the edit), and restoring a version sticks.

## Root cause
File content is entangled with the (currently broken) live-editing layer:

- With live editing "enabled", the editor mounts bound to an **empty Yjs doc** (`content: undefined` in `simple-editor.tsx`), and the real saved content is only injected once the Supabase realtime channel **connects and this client is elected leader** — the `shouldLoadInitialContent` gate in `use-supabase-yjs-collaboration.ts`.
- Realtime is currently failing to connect, so that seed runs late or **never**. The editor can present blank/stale content, and the debounced auto-save then persists that over the real edit.
- This is exactly why the loss is intermittent ("may or may not"), why the DB copy survives (others/version history see it), and why **restoring a version sticks** — that's a direct DB write that bypasses the Yjs seed.

## The fix
Decouple persistence from live editing. A `LIVE_EDITING_ENABLED = false` flag on the page and sheet routes stops passing `realtimeDocumentId`, so both editors load and save **directly from the database** — the deterministic path the team already hardened (pending-save gate, visit-scoped seeding, unmount flush).

Live editing is re-enabled by flipping the flag once (a) the Supabase realtime connection is verified working and (b) seeding is reworked so it never gates whether you can see/save your own content.

## Note on Hocuspocus
`src/hooks/use-yjs-collaboration.ts` and `hocuspocus/app.ts` are now **dead code** — the editors use the Supabase hook. Safe to delete in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)