### PR TITLE
Collaborative editing: DB-persisted Yjs (documents)

### DIFF
--- a/drizzle/0002_add_page_yjs_state.sql
+++ b/drizzle/0002_add_page_yjs_state.sql
@@ -1,0 +1,5 @@
+-- Adds the canonical Yjs (CRDT) document state column for true simultaneous
+-- editing. NULL means the page has never been opened collaboratively yet; the
+-- first collaborative open seeds it from the existing HTML content.
+ALTER TABLE "safe-cities-project-management-v2_page_content"
+    ADD COLUMN IF NOT EXISTS "yjsState" text;

--- a/src/app/pages/[pageId]/page.tsx
+++ b/src/app/pages/[pageId]/page.tsx
@@ -22,7 +22,7 @@ type Permission = 'view' | 'comment' | 'edit'
 // directly from the database (deterministic). Re-enable only once realtime is
 // verified working AND seeding no longer gates content. See
 // docs/LIVE_EDITING_SUPABASE.md.
-const LIVE_EDITING_ENABLED = false
+const LIVE_EDITING_ENABLED = true
 
 export default function PageView() {
     const params = useParams()
@@ -146,6 +146,9 @@ export default function PageView() {
     const lastPersistedContentRef = useRef<string>('')
     // Latest unsaved content + stable mutate ref, for the unmount flush below
     const latestContentRef = useRef<string>('')
+    // Latest canonical Yjs state from the collaborative editor, persisted
+    // alongside the HTML so the merged document survives reloads.
+    const latestYjsStateRef = useRef<string | undefined>(undefined)
     const savePageRef = useRef(updatePageMutation.mutateAsync)
     savePageRef.current = updatePageMutation.mutateAsync
 
@@ -179,7 +182,9 @@ export default function PageView() {
 
     // Handle content change with debounced saving
     const handleContentChange = useCallback(
-        (newContent: string) => {
+        (newContent: string, yjsState?: string) => {
+            // Keep the latest Yjs state for the debounced save + unmount flush.
+            if (yjsState !== undefined) latestYjsStateRef.current = yjsState
             // Ignore no-op updates (e.g. the editor re-emitting content we just
             // loaded into it) so they don't schedule pointless saves.
             if (newContent === latestContentRef.current) return
@@ -205,6 +210,7 @@ export default function PageView() {
                     updatePageMutation.mutateAsync({
                         fileId: pageId,
                         content: newContent,
+                        yjsState: latestYjsStateRef.current,
                     })
                 )
             }, 1500) // 1.5 seconds debounce interval (server waits 1.5 seconds after no more keystroke to save)
@@ -224,6 +230,7 @@ export default function PageView() {
                     savePageRef.current({
                         fileId: pageId,
                         content: latestContentRef.current,
+                        yjsState: latestYjsStateRef.current,
                     })
                 )
             }
@@ -421,6 +428,11 @@ export default function PageView() {
             <div className="flex-1 min-h-0 flex flex-col justify-start items-center bg-background">
                 <SimpleEditor
                     initialContent={content}
+                    initialYjsState={
+                        page?.content && 'yjsState' in page.content
+                            ? (page.content.yjsState ?? null)
+                            : null
+                    }
                     readOnly={isReadOnly}
                     realtimeDocumentId={
                         LIVE_EDITING_ENABLED ? pageId : undefined

--- a/src/components/tiptap-templates/simple/simple-editor.tsx
+++ b/src/components/tiptap-templates/simple/simple-editor.tsx
@@ -6,6 +6,10 @@ import { EditorContent, EditorContext, useEditor } from '@tiptap/react'
 // --- Tiptap Core Extensions ---
 import { StarterKit } from '@tiptap/starter-kit'
 import { Collaboration, isChangeOrigin } from '@tiptap/extension-collaboration'
+import * as Y from 'yjs'
+import { prosemirrorToYDoc } from 'y-prosemirror'
+import { DOMParser as PMDOMParser, type Schema } from '@tiptap/pm/model'
+import { api } from '~/trpc/react'
 import { TaskList } from '@tiptap/extension-task-list'
 import { TextAlign } from '@tiptap/extension-text-align'
 import { Typography } from '@tiptap/extension-typography'
@@ -211,16 +215,50 @@ function getPermissionLabel(permission: 'view' | 'comment' | 'edit') {
     return 'viewer'
 }
 
+// Yjs document state travels to/from the server as base64 text.
+function bytesToBase64(bytes: Uint8Array) {
+    let binary = ''
+    for (let index = 0; index < bytes.length; index += 1) {
+        binary += String.fromCharCode(bytes[index]!)
+    }
+    return window.btoa(binary)
+}
+
+function base64ToBytes(value: string) {
+    const binary = window.atob(value)
+    const bytes = new Uint8Array(binary.length)
+    for (let index = 0; index < binary.length; index += 1) {
+        bytes[index] = binary.charCodeAt(index)
+    }
+    return bytes
+}
+
+// Build a Yjs document from existing HTML using the editor's own schema, so the
+// seeded CRDT state matches exactly what the Collaboration extension expects.
+// 'default' is Tiptap Collaboration's XML fragment name — it must match here.
+function htmlToYjsState(html: string, schema: Schema): Uint8Array {
+    const body = new window.DOMParser().parseFromString(
+        html && html.trim() ? html : '<p></p>',
+        'text/html'
+    ).body
+    const pmNode = PMDOMParser.fromSchema(schema).parse(body)
+    const doc = prosemirrorToYDoc(pmNode, 'default')
+    return Y.encodeStateAsUpdate(doc)
+}
+
 interface SimpleEditorProps {
     initialContent?: string
+    // Canonical Yjs state (base64) from the DB. null/undefined = not seeded yet.
+    initialYjsState?: string | null
     readOnly?: boolean
-    onUpdate?: (content: string) => void
+    onUpdate?: (content: string, yjsState?: string) => void
     realtimeDocumentId?: string | number
     permission?: 'view' | 'comment' | 'edit'
 }
 
 export function SimpleEditor({
     initialContent,
+    initialYjsState,
     readOnly = false,
     onUpdate,
     realtimeDocumentId,
@@ -243,13 +281,19 @@ export function SimpleEditor({
     const {
         clientId,
         lastError: collaborationLastError,
-        markInitialContentLoaded,
         presenceUsers,
-        shouldLoadInitialContent,
         status: collaborationStatus,
         updatePresenceMetadata,
         ydoc,
     } = collaboration
+
+    // Loads the canonical Yjs state into the doc exactly once, deterministically,
+    // and independent of the realtime connection (this is what prevents the
+    // "content only appears if the socket connects" data-loss class of bug).
+    const canonicalLoadedRef = React.useRef(false)
+    const seedYjsState = api.files.seedYjsStateIfAbsent.useMutation()
+    const seedYjsStateRef = React.useRef(seedYjsState.mutateAsync)
+    seedYjsStateRef.current = seedYjsState.mutateAsync
 
     const editor = useEditor({
         immediatelyRender: false,
@@ -422,7 +466,12 @@ export function SimpleEditor({
             if (collaborationEnabled && isChangeOrigin(transaction)) return
 
             const htmlContent = editor.getHTML()
-            onUpdate(htmlContent)
+            // In collaborative mode, persist the full merged CRDT state (HTML is
+            // kept too, for version history / exports / the non-collab path).
+            const yjsState = collaborationEnabled
+                ? bytesToBase64(Y.encodeStateAsUpdate(ydoc))
+                : undefined
+            onUpdate(htmlContent, yjsState)
         }
 
         editor.on('update', handleUpdate)
@@ -430,7 +479,7 @@ export function SimpleEditor({
         return () => {
             editor.off('update', handleUpdate)
         }
-    }, [collaborationEnabled, editor, onUpdate])
+    }, [collaborationEnabled, editor, onUpdate, ydoc])
 
     // Handle initialContent changes from parent. Never while the editor is
     // focused — resetting mid-typing would drop keystrokes and the caret.
@@ -447,25 +496,52 @@ export function SimpleEditor({
         }
     }, [collaborationEnabled, editor, initialContent])
 
+    // Deterministic canonical load. Runs once when the editor is ready — NOT
+    // gated on the realtime connection, so your content always appears and can
+    // never be silently replaced by an empty doc while the socket is down.
     React.useEffect(() => {
-        if (!collaborationEnabled || !editor || !shouldLoadInitialContent) {
+        if (!collaborationEnabled || !editor || canonicalLoadedRef.current) {
             return
         }
+        canonicalLoadedRef.current = true
 
-        const contentToLoad =
-            initialContent && initialContent.trim() !== ''
-                ? initialContent
-                : '<p></p>'
+        let cancelled = false
+        void (async () => {
+            let canonicalBase64 = initialYjsState ?? null
 
-        editor.commands.setContent(contentToLoad)
-        markInitialContentLoaded()
-    }, [
-        collaborationEnabled,
-        editor,
-        initialContent,
-        markInitialContentLoaded,
-        shouldLoadInitialContent,
-    ])
+            // No canonical state yet: seed it from the existing HTML and claim it
+            // atomically. Whoever wins, everyone applies the SAME returned state,
+            // so two simultaneous first-openers can't create divergent copies.
+            if (!canonicalBase64) {
+                const seedBase64 = bytesToBase64(
+                    htmlToYjsState(initialContent ?? '', editor.schema)
+                )
+                try {
+                    const result = await seedYjsStateRef.current({
+                        fileId: Number(realtimeDocumentId),
+                        yjsState: seedBase64,
+                    })
+                    canonicalBase64 = result.yjsState ?? seedBase64
+                } catch (error) {
+                    // Offline / seed failed: fall back to local content so the
+                    // user can still see and edit; the next save persists it.
+                    console.warn(
+                        'Live editing: seeding failed, using local content',
+                        error
+                    )
+                    canonicalBase64 = seedBase64
+                }
+            }
+
+            if (cancelled || !canonicalBase64) return
+            Y.applyUpdate(ydoc, base64ToBytes(canonicalBase64))
+        })()
+
+        return () => {
+            cancelled = true
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [collaborationEnabled, editor, ydoc])
 
     // Handle readOnly prop changes
     React.useEffect(() => {

--- a/src/hooks/use-supabase-yjs-collaboration.ts
+++ b/src/hooks/use-supabase-yjs-collaboration.ts
@@ -48,6 +48,11 @@ type SupabaseBrowserClient = ReturnType<typeof createClient<any, 'public', any>>
 const REMOTE_ORIGIN = Symbol('supabase-realtime-remote')
 const SUBSCRIBE_TIMEOUT_MS = 10_000
 const HEARTBEAT_INTERVAL_MS = 5_000
+// A live client re-broadcasts its presence every HEARTBEAT_INTERVAL_MS, so any
+// presence not refreshed within this window is a dead session (an unclean
+// disconnect the server hasn't reaped) and is hidden. Generous enough to absorb
+// small clock differences between machines and a couple of missed heartbeats.
+const PRESENCE_FRESH_MS = 20_000
 const RECONNECT_DELAY_MS = 500
 const CHANNEL_OPERATION_TIMEOUT_MS = 5_000
 const HEARTBEAT_FAILURES_BEFORE_RECONNECT = 3
@@ -309,7 +314,28 @@ function isYDocEmpty(ydoc: Y.Doc) {
 function flattenPresenceState(
     state: Record<string, PresenceUser[]>
 ): PresenceUser[] {
-    return Object.values(state).flat().filter(Boolean)
+    const now = Date.now()
+    // Keep only the freshest presence per client id. Reconnects and unclean
+    // disconnects can leave several entries for the same (or a dead) session;
+    // collapsing by client id + dropping stale ones stops phantom cursors and
+    // an inflated "who's online" count.
+    const latestByClient = new Map<string, PresenceUser>()
+    for (const presences of Object.values(state)) {
+        for (const presence of presences) {
+            if (!presence?.clientId) continue
+            const existing = latestByClient.get(presence.clientId)
+            if (
+                !existing ||
+                (presence.joinedAt ?? 0) > (existing.joinedAt ?? 0)
+            ) {
+                latestByClient.set(presence.clientId, presence)
+            }
+        }
+    }
+
+    return [...latestByClient.values()].filter(
+        (presence) => now - (presence.joinedAt ?? 0) < PRESENCE_FRESH_MS
+    )
 }
 
 function getClientId() {

--- a/src/server/api/routers/files.ts
+++ b/src/server/api/routers/files.ts
@@ -1,4 +1,14 @@
-import { eq, sql, desc, asc, ne, and, isNotNull, inArray } from 'drizzle-orm'
+import {
+    eq,
+    sql,
+    desc,
+    asc,
+    ne,
+    and,
+    isNull,
+    isNotNull,
+    inArray,
+} from 'drizzle-orm'
 import { z } from 'zod'
 
 import {
@@ -662,6 +672,10 @@ export const filesRouter = createTRPCRouter({
             z.object({
                 fileId: z.number(),
                 content: z.string(),
+                // Canonical Yjs state (base64). Sent by the collaborative editor
+                // so the merged document survives reloads. Optional so the plain
+                // (non-collaborative) save path keeps working unchanged.
+                yjsState: z.string().optional(),
             })
         )
         .mutation(async ({ ctx, input }) => {
@@ -714,11 +728,16 @@ export const filesRouter = createTRPCRouter({
                         .where(inArray(pageVersionHistory.id, idsToDelete))
                 }
 
-                // Update the page content with incremented version
+                // Update the page content with incremented version. yjsState is
+                // only written when the collaborative editor supplies it, so the
+                // plain save path never clobbers it with undefined.
                 await ctx.db
                     .update(pageContent)
                     .set({
                         content: input.content,
+                        ...(input.yjsState !== undefined
+                            ? { yjsState: input.yjsState }
+                            : {}),
                         version: (currentPage.version ?? 0) + 1,
                         updatedAt: new Date(),
                     })
@@ -728,6 +747,7 @@ export const filesRouter = createTRPCRouter({
                 await ctx.db.insert(pageContent).values({
                     fileId: input.fileId,
                     content: input.content,
+                    yjsState: input.yjsState,
                     version: 1,
                 })
             }
@@ -777,6 +797,61 @@ export const filesRouter = createTRPCRouter({
             }
 
             return { success: true }
+        }),
+
+    // Seed the canonical Yjs state for a page ONLY if it doesn't have one yet.
+    // This is the atomic guard that stops two people who open a fresh document at
+    // the same time from creating two divergent collaborative copies: the write
+    // only lands where yjsState IS NULL, so exactly one client wins. Everyone
+    // (winner and losers) then uses the yjsState this returns as canonical.
+    seedYjsStateIfAbsent: protectedProcedure
+        .input(
+            z.object({
+                fileId: z.number(),
+                yjsState: z.string(),
+            })
+        )
+        .mutation(async ({ ctx, input }) => {
+            const { userId } = ctx.auth
+
+            const permissionContext = await getUserPermissionContext(userId)
+            const ancestors = await getFileAncestors(input.fileId)
+            const canEdit = hasPermissionInContext(
+                permissionContext,
+                input.fileId,
+                'edit',
+                ancestors.map((ancestor) => ancestor.id)
+            )
+            if (!canEdit) {
+                throw new TRPCError({
+                    code: 'FORBIDDEN',
+                    message: 'You do not have permission to edit this page',
+                })
+            }
+
+            // Atomic compare-and-set: only writes where yjsState IS NULL.
+            const won = await ctx.db
+                .update(pageContent)
+                .set({ yjsState: input.yjsState })
+                .where(
+                    and(
+                        eq(pageContent.fileId, input.fileId),
+                        isNull(pageContent.yjsState)
+                    )
+                )
+                .returning({ yjsState: pageContent.yjsState })
+
+            if (won.length > 0) {
+                return { yjsState: input.yjsState, seeded: true }
+            }
+
+            // Someone else already seeded (or it already had state). Return the
+            // canonical value so this client adopts it instead of its own seed.
+            const existing = await ctx.db.query.pageContent.findFirst({
+                where: eq(pageContent.fileId, input.fileId),
+                columns: { yjsState: true },
+            })
+            return { yjsState: existing?.yjsState ?? null, seeded: false }
         }),
 
     // Update sheet content

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -122,7 +122,11 @@ export const pageContent = createTable('page_content', (d) => ({
         .integer()
         .references(() => files.id, { onDelete: 'cascade' })
         .primaryKey(),
-    content: d.text().default(''),
+    content: d.text().default(''), // HTML — the human-readable / exportable copy
+    // Canonical Yjs (CRDT) document state as base64, for true simultaneous
+    // editing. NULL = this page has never been opened collaboratively yet; the
+    // first collaborative open seeds it from `content` (see seedYjsStateIfAbsent).
+    yjsState: d.text(),
     version: d.integer().default(1), // For versioning support
     createdAt: d.timestamp().notNull().defaultNow(),
     updatedAt: d.timestamp().defaultNow(),


### PR DESCRIPTION
## ⚠️ Testing branch — do not merge until verified
Document live editing is turned ON here (pages only; sheets stay off) so we can test on the Vercel **preview** without touching production.

## What to test on the preview
1. Open a **document**, type, wait for "saved", **hard-refresh** → text is still there.
2. Leave to another file, come back → text is still there.
3. Open the **same doc in two browsers** (e.g. normal + incognito, both signed in) and edit → whether live-sync works yet depends on Stage 3 (the realtime connection), but **neither browser should lose content**, and reopening either should show the merged result.

## Architecture (Stages 1–2)
The database is the canonical copy. The editor loads the merged Yjs state from Postgres deterministically on open (never gated on the connection) and saves the merged state + HTML together. Data safety no longer depends on the socket.

- `pageContent.yjsState` column (base64 CRDT state)
- `updatePageContent` persists it; `seedYjsStateIfAbsent` atomically claims the first-seed so two openers can't fork a fresh doc
- editor: deterministic canonical load + full-state save; old connection-gated seeding removed

## Still to come
- Stage 3: make the live realtime connection work (Clerk↔Supabase auth) — enables watch-each-other-type.
- Stage 4: full verification.
- Sheets: separate, later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)