### PR TITLE
Cell-level collaborative editing (spreadsheets)

### DIFF
--- a/drizzle/0003_add_sheet_yjs_state.sql
+++ b/drizzle/0003_add_sheet_yjs_state.sql
@@ -1,0 +1,4 @@
+-- Adds the canonical Yjs (CRDT) state column for cell-level simultaneous sheet
+-- editing. NULL until the sheet is first opened collaboratively.
+ALTER TABLE "safe-cities-project-management-v2_sheet_content"
+    ADD COLUMN IF NOT EXISTS "yjsState" text;

--- a/src/app/sheets/[sheetId]/page.tsx
+++ b/src/app/sheets/[sheetId]/page.tsx
@@ -18,7 +18,7 @@ type PermissionType = 'view' | 'comment' | 'edit'
 // with a flaky connection and risks edits being overwritten. With this off,
 // sheets load and save directly from the database. See the note in
 // src/app/pages/[pageId]/page.tsx and docs/LIVE_EDITING_SUPABASE.md.
-const LIVE_EDITING_ENABLED = false
+const LIVE_EDITING_ENABLED = true
 
 export default function SheetPage() {
     const params = useParams()
@@ -232,6 +232,11 @@ export default function SheetPage() {
             <div className="flex-1 min-h-0">
                 <SheetEditor
                     initialData={sheetDataToUse}
+                    initialYjsState={
+                        sheet.content && 'yjsState' in sheet.content
+                            ? (sheet.content.yjsState ?? null)
+                            : null
+                    }
                     sheetId={sheetId}
                     sheetName={sheet.name}
                     readOnly={isReadOnly}

--- a/src/components/sheet-editor.tsx
+++ b/src/components/sheet-editor.tsx
@@ -624,16 +624,22 @@ export function SheetEditor({
     }
 
     const getCellLabel = useCallback((location: CellLocation) => {
-        const columnIndex =
+        const rawColumnIndex =
             typeof location.columnId === 'number'
                 ? location.columnId
                 : Number(location.columnId)
+        // Grid column 0 is the row-number header, so data column A is grid
+        // index 1 — shift back by one to get the spreadsheet letter.
+        const columnIndex = rawColumnIndex - 1
+
         const rowId = String(location.rowId)
+        // "row-N" already encodes the displayed row number N; don't add to it.
         const rowNumber = rowId.startsWith('row-')
-            ? Number(rowId.replace('row-', '')) + 1
+            ? rowId.replace('row-', '')
             : rowId
 
         const getColumnLetter = (index: number): string => {
+            if (index < 0) return ''
             let result = ''
             let value = Number.isFinite(index) ? index : 0
 

--- a/src/components/sheet-editor.tsx
+++ b/src/components/sheet-editor.tsx
@@ -24,6 +24,13 @@ import { Card, CardContent } from '~/components/ui/card'
 import { Plus, Activity, Shield, Info, Undo, Redo } from 'lucide-react'
 import { useSupabaseYjsCollaboration as useYjsCollaboration } from '~/hooks/use-supabase-yjs-collaboration'
 import * as Y from 'yjs'
+import {
+    applySheetToCrdt,
+    crdtToSheet,
+    isSheetCrdtEmpty,
+    bytesToBase64,
+    base64ToBytes,
+} from '~/lib/sheet-crdt'
 
 function getPermissionLabel(permission: 'view' | 'comment' | 'edit') {
     if (permission === 'edit') return 'editor'
@@ -33,6 +40,8 @@ function getPermissionLabel(permission: 'view' | 'comment' | 'edit') {
 
 interface SheetEditorProps {
     initialData: SheetData
+    // Canonical Yjs state (base64) from the DB. null/undefined = not seeded yet.
+    initialYjsState?: string | null
     sheetId: number
     sheetName?: string
     readOnly?: boolean
@@ -52,6 +61,7 @@ interface SheetEditorProps {
 
 export function SheetEditor({
     initialData,
+    initialYjsState,
     sheetId,
     sheetName,
     readOnly = false,
@@ -72,9 +82,7 @@ export function SheetEditor({
     const {
         clientId,
         lastError: collaborationLastError,
-        markInitialContentLoaded,
         presenceUsers,
-        shouldLoadInitialContent,
         status: collaborationStatus,
         updatePresenceMetadata,
         ydoc,
@@ -82,9 +90,17 @@ export function SheetEditor({
     const currentPresenceColor =
         presenceUsers.find((presenceUser) => presenceUser.clientId === clientId)
             ?.color ?? '#7c3aed'
-    const sheetMap = React.useMemo(() => ydoc.getMap<string>('sheet'), [ydoc])
     const applyingRemoteChangeRef = useRef(false)
     const sheetLocalOriginRef = useRef(Symbol('sheet-local-update'))
+
+    // Loads the canonical sheet CRDT once, deterministically, independent of the
+    // realtime connection (same data-safety guarantee as documents).
+    const canonicalLoadedRef = useRef(false)
+    const seedSheetYjsState = api.files.seedSheetYjsStateIfAbsent.useMutation()
+    const seedSheetYjsStateRef = useRef(seedSheetYjsState.mutateAsync)
+    seedSheetYjsStateRef.current = seedSheetYjsState.mutateAsync
+    // Latest canonical Yjs state, persisted with the JSON content on save.
+    const latestYjsStateRef = useRef<string | undefined>(undefined)
     const sheetRef = useRef<SheetData>(initialData)
     const focusedCellRef = useRef<CellLocation | null>(null)
     const remoteCellHighlights = React.useMemo<Highlight[]>(
@@ -183,28 +199,36 @@ export function SheetEditor({
             saveTimeoutRef.current = setTimeout(() => {
                 saveTimeoutRef.current = null
                 onSavingStatusChange?.('saving')
+                // Derive BOTH the JSON content and the Yjs state from the merged
+                // CRDT so they stay consistent (the doc may have absorbed remote
+                // edits since this local change).
+                const contentToSave = collaborationEnabled
+                    ? JSON.stringify(crdtToSheet(ydoc))
+                    : serializedSheet
+                const yjsState = collaborationEnabled
+                    ? bytesToBase64(Y.encodeStateAsUpdate(ydoc))
+                    : undefined
+                if (yjsState !== undefined) latestYjsStateRef.current = yjsState
                 trackPendingSave(
                     sheetId,
                     updateMutation.mutateAsync({
                         fileId: sheetId,
-                        content: serializedSheet,
+                        content: contentToSave,
+                        yjsState,
                     })
                 )
             }, 5000)
         },
-        [sheetId, updateMutation, onSavingStatusChange]
+        [sheetId, updateMutation, onSavingStatusChange, collaborationEnabled, ydoc]
     )
 
+    // Publish local edits into the cell-level CRDT (writes only changed cells).
     const publishSheetToRealtime = useCallback(
         (sheetData: SheetData) => {
             if (!collaborationEnabled) return
-
-            ydoc.transact(() => {
-                sheetMap.set('data', JSON.stringify(sheetData))
-                sheetMap.set('updatedAt', String(Date.now()))
-            }, sheetLocalOriginRef.current)
+            applySheetToCrdt(ydoc, sheetData, sheetLocalOriginRef.current)
         },
-        [collaborationEnabled, sheetMap, ydoc]
+        [collaborationEnabled, ydoc]
     )
 
     // Commit a new sheet state: updates the sheet, pushes a snapshot to history, and saves.
@@ -225,66 +249,85 @@ export function SheetEditor({
         [historyIndex, publishSheetToRealtime, debouncedSave]
     )
 
+    // Apply remote CRDT changes. Fires once per transaction; skips our own
+    // edits (localOrigin) and rebuilds the sheet from the merged cell state.
     useEffect(() => {
         if (!collaborationEnabled) return
 
-        const handleRemoteSheetChange = (event: Y.YMapEvent<string>) => {
-            if (event.transaction.origin === sheetLocalOriginRef.current) return
-            if (!event.keysChanged.has('data')) return
+        const handleUpdate = (_update: Uint8Array, origin: unknown) => {
+            if (origin === sheetLocalOriginRef.current) return
+            if (isSheetCrdtEmpty(ydoc)) return
 
-            const data = sheetMap.get('data')
-            if (!data) return
-
-            try {
-                const nextSheet = JSON.parse(data) as SheetData
-                if (
-                    !nextSheet?.rows ||
-                    !Array.isArray(nextSheet.rows) ||
-                    !nextSheet?.cells ||
-                    !Array.isArray(nextSheet.cells)
-                ) {
-                    return
-                }
-
-                applyingRemoteChangeRef.current = true
-                setSheet(nextSheet)
-                lastPersistedSheetJsonRef.current = data
-                setHistory((prev) => {
-                    const next = [...prev, nextSheet]
-                    return next.length > 50 ? next.slice(-50) : next
-                })
-                setHistoryIndex((prev) => Math.min(prev + 1, 50))
-                window.setTimeout(() => {
-                    applyingRemoteChangeRef.current = false
-                }, 0)
-            } catch (error) {
-                console.warn('Failed to apply remote sheet update', error)
-            }
+            const nextSheet = crdtToSheet(ydoc)
+            applyingRemoteChangeRef.current = true
+            setSheet(nextSheet)
+            sheetRef.current = nextSheet
+            // The originating client persists the change; mark it as the known
+            // saved state here so this receiver doesn't redundantly re-save it.
+            lastPersistedSheetJsonRef.current = JSON.stringify(nextSheet)
+            window.setTimeout(() => {
+                applyingRemoteChangeRef.current = false
+            }, 0)
         }
 
-        sheetMap.observe(handleRemoteSheetChange)
+        ydoc.on('update', handleUpdate)
+        return () => {
+            ydoc.off('update', handleUpdate)
+        }
+    }, [collaborationEnabled, ydoc])
+
+    // Deterministic canonical load — once, independent of the connection. Loads
+    // the DB's Yjs state, or seeds it from initialData through the atomic guard
+    // so two simultaneous first-openers can't fork the sheet.
+    useEffect(() => {
+        if (!collaborationEnabled || canonicalLoadedRef.current) return
+        canonicalLoadedRef.current = true
+
+        let cancelled = false
+        void (async () => {
+            let canonicalBase64 = initialYjsState ?? null
+
+            if (!canonicalBase64) {
+                const seedDoc = new Y.Doc()
+                applySheetToCrdt(seedDoc, initialData, 'seed')
+                const seedBase64 = bytesToBase64(
+                    Y.encodeStateAsUpdate(seedDoc)
+                )
+                try {
+                    const result = await seedSheetYjsStateRef.current({
+                        fileId: Number(realtimeDocumentId),
+                        yjsState: seedBase64,
+                    })
+                    canonicalBase64 = result.yjsState ?? seedBase64
+                } catch (error) {
+                    console.warn(
+                        'Live sheet seeding failed; using local data',
+                        error
+                    )
+                    canonicalBase64 = seedBase64
+                }
+            }
+
+            if (cancelled || !canonicalBase64) return
+            // localOrigin so the update handler above ignores it; we setSheet here.
+            Y.applyUpdate(
+                ydoc,
+                base64ToBytes(canonicalBase64),
+                sheetLocalOriginRef.current
+            )
+            const nextSheet = crdtToSheet(ydoc)
+            if (nextSheet.rows.length > 0) {
+                setSheet(nextSheet)
+                sheetRef.current = nextSheet
+                lastPersistedSheetJsonRef.current = JSON.stringify(nextSheet)
+            }
+        })()
 
         return () => {
-            sheetMap.unobserve(handleRemoteSheetChange)
+            cancelled = true
         }
-    }, [collaborationEnabled, sheetMap])
-
-    useEffect(() => {
-        if (!collaborationEnabled || !shouldLoadInitialContent) return
-
-        if (!sheetMap.get('data')) {
-            publishSheetToRealtime(sheet)
-        }
-
-        markInitialContentLoaded()
-    }, [
-        collaborationEnabled,
-        markInitialContentLoaded,
-        publishSheetToRealtime,
-        sheet,
-        sheetMap,
-        shouldLoadInitialContent,
-    ])
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [collaborationEnabled, ydoc])
 
     // Apply a rename to a header cell (column header or row label)
     const applyRename = useCallback(
@@ -456,6 +499,7 @@ export function SheetEditor({
                     saveSheetRef.current({
                         fileId: sheetId,
                         content: JSON.stringify(sheetRef.current),
+                        yjsState: latestYjsStateRef.current,
                     })
                 )
             }

--- a/src/lib/sheet-crdt.ts
+++ b/src/lib/sheet-crdt.ts
@@ -1,0 +1,125 @@
+// Cell-level CRDT model for spreadsheets, backed by Yjs.
+//
+// A sheet is represented as:
+//   - cells:    Y.Map<string>  keyed by `${rowId}::${col}` -> JSON of the cell.
+//               This is the merge granularity: two people editing different
+//               cells touch different keys, so both survive.
+//   - rowOrder: Y.Array<string> of rowIds, giving row order + existence.
+//   - meta:     Y.Map          `colCount` (number) and `h:${rowId}` (row height).
+//
+// The same helper (applySheetToCrdt) both seeds an empty doc and publishes
+// incremental edits — it only writes keys whose value actually changed.
+
+import * as Y from 'yjs'
+import { type DefaultCellTypes, type Row } from '@silevis/reactgrid'
+import { type SheetData } from './sheet-utils'
+
+const CELLS_KEY = 'sheetCells'
+const ROW_ORDER_KEY = 'sheetRowOrder'
+const META_KEY = 'sheetMeta'
+const COL_COUNT = 'colCount'
+
+export function bytesToBase64(bytes: Uint8Array) {
+    let binary = ''
+    for (let index = 0; index < bytes.length; index += 1) {
+        binary += String.fromCharCode(bytes[index]!)
+    }
+    return window.btoa(binary)
+}
+
+export function base64ToBytes(value: string) {
+    const binary = window.atob(value)
+    const bytes = new Uint8Array(binary.length)
+    for (let index = 0; index < binary.length; index += 1) {
+        bytes[index] = binary.charCodeAt(index)
+    }
+    return bytes
+}
+
+function parts(doc: Y.Doc) {
+    return {
+        cells: doc.getMap<string>(CELLS_KEY),
+        rowOrder: doc.getArray<string>(ROW_ORDER_KEY),
+        meta: doc.getMap(META_KEY),
+    }
+}
+
+function cellKey(rowId: string, col: number) {
+    return `${rowId}::${col}`
+}
+
+/** True until the sheet has been seeded (no rows yet). */
+export function isSheetCrdtEmpty(doc: Y.Doc): boolean {
+    return doc.getArray<string>(ROW_ORDER_KEY).length === 0
+}
+
+/** Reconstruct a full SheetData from the CRDT. */
+export function crdtToSheet(doc: Y.Doc): SheetData {
+    const { cells, rowOrder, meta } = parts(doc)
+    const colCount = Number(meta.get(COL_COUNT) ?? 0)
+
+    const rows: Row[] = rowOrder.toArray().map((rowId) => {
+        const rowCells: DefaultCellTypes[] = []
+        for (let col = 0; col < colCount; col += 1) {
+            const raw = cells.get(cellKey(rowId, col))
+            rowCells.push(
+                raw
+                    ? (JSON.parse(raw) as DefaultCellTypes)
+                    : ({ type: 'text', text: '' } as DefaultCellTypes)
+            )
+        }
+        return {
+            rowId,
+            height: Number(meta.get(`h:${rowId}`) ?? 35),
+            cells: rowCells,
+        }
+    })
+
+    return { rows, cells: rows.map((row) => row.cells) }
+}
+
+/**
+ * Write a SheetData into the CRDT inside one transaction, touching only keys
+ * whose value actually changed. Used both to seed an empty doc (everything is
+ * "changed") and to publish incremental local edits (only the edited cells).
+ * Skipping unchanged keys also stops remote-applied cells from echoing back.
+ */
+export function applySheetToCrdt(
+    doc: Y.Doc,
+    sheet: SheetData,
+    origin: unknown
+) {
+    const { cells, rowOrder, meta } = parts(doc)
+
+    doc.transact(() => {
+        const colCount = sheet.rows[0]?.cells.length ?? 0
+        if (Number(meta.get(COL_COUNT) ?? -1) !== colCount) {
+            meta.set(COL_COUNT, colCount)
+        }
+
+        const newRowIds = sheet.rows.map((row) => String(row.rowId))
+        const currentRowIds = rowOrder.toArray()
+        const rowOrderChanged =
+            newRowIds.length !== currentRowIds.length ||
+            newRowIds.some((id, index) => id !== currentRowIds[index])
+        if (rowOrderChanged) {
+            rowOrder.delete(0, rowOrder.length)
+            rowOrder.push(newRowIds)
+        }
+
+        for (const row of sheet.rows) {
+            const heightKey = `h:${row.rowId}`
+            const height = row.height ?? 35
+            if (Number(meta.get(heightKey) ?? -1) !== height) {
+                meta.set(heightKey, height)
+            }
+            row.cells.forEach((cell, col) => {
+                const key = cellKey(String(row.rowId), col)
+                const json = JSON.stringify(cell)
+                if (cells.get(key) !== json) {
+                    cells.set(key, json)
+                }
+            })
+        }
+    }, origin)
+}

--- a/src/server/api/routers/files.ts
+++ b/src/server/api/routers/files.ts
@@ -854,6 +854,55 @@ export const filesRouter = createTRPCRouter({
             return { yjsState: existing?.yjsState ?? null, seeded: false }
         }),
 
+    // Atomic first-seed for a sheet's canonical Yjs state (same guard as the
+    // page version above, targeting sheetContent).
+    seedSheetYjsStateIfAbsent: protectedProcedure
+        .input(
+            z.object({
+                fileId: z.number(),
+                yjsState: z.string(),
+            })
+        )
+        .mutation(async ({ ctx, input }) => {
+            const { userId } = ctx.auth
+
+            const permissionContext = await getUserPermissionContext(userId)
+            const ancestors = await getFileAncestors(input.fileId)
+            const canEdit = hasPermissionInContext(
+                permissionContext,
+                input.fileId,
+                'edit',
+                ancestors.map((ancestor) => ancestor.id)
+            )
+            if (!canEdit) {
+                throw new TRPCError({
+                    code: 'FORBIDDEN',
+                    message: 'You do not have permission to edit this sheet',
+                })
+            }
+
+            const won = await ctx.db
+                .update(sheetContent)
+                .set({ yjsState: input.yjsState })
+                .where(
+                    and(
+                        eq(sheetContent.fileId, input.fileId),
+                        isNull(sheetContent.yjsState)
+                    )
+                )
+                .returning({ yjsState: sheetContent.yjsState })
+
+            if (won.length > 0) {
+                return { yjsState: input.yjsState, seeded: true }
+            }
+
+            const existing = await ctx.db.query.sheetContent.findFirst({
+                where: eq(sheetContent.fileId, input.fileId),
+                columns: { yjsState: true },
+            })
+            return { yjsState: existing?.yjsState ?? null, seeded: false }
+        }),
+
     // Update sheet content
     updateSheetContent: protectedProcedure
         .input(
@@ -861,6 +910,9 @@ export const filesRouter = createTRPCRouter({
                 fileId: z.number(),
                 content: z.string(),
                 schema: z.string().optional(),
+                // Canonical Yjs state (base64) for cell-level collaboration.
+                // Optional so the plain save path keeps working unchanged.
+                yjsState: z.string().optional(),
             })
         )
         .mutation(async ({ ctx, input }) => {
@@ -914,12 +966,16 @@ export const filesRouter = createTRPCRouter({
                 }
             }
 
-            // Update the sheet content with incremented version
+            // Update the sheet content with incremented version. yjsState is
+            // only written when the collaborative editor supplies it.
             await ctx.db
                 .update(sheetContent)
                 .set({
                     content: input.content,
                     schema: input.schema,
+                    ...(input.yjsState !== undefined
+                        ? { yjsState: input.yjsState }
+                        : {}),
                     version: (currentSheet?.version ?? 0) + 1,
                     updatedAt: new Date(),
                 })

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -171,6 +171,10 @@ export const sheetContent = createTable('sheet_content', (d) => ({
         .references(() => files.id, { onDelete: 'cascade' })
         .primaryKey(),
     content: d.text().default('[]'), // JSON string of sheet data
+    // Canonical Yjs (CRDT) state as base64, for true cell-level simultaneous
+    // editing. NULL = never opened collaboratively; first collab open seeds it
+    // from `content` (see seedSheetYjsStateIfAbsent).
+    yjsState: d.text(),
     schema: d.text(), // JSON string of column definitions
     version: d.integer().default(1), // For versioning support
     createdAt: d.timestamp().notNull().defaultNow(),


### PR DESCRIPTION
## ⚠️ Testing branch — do not merge until verified
Spreadsheet live editing is turned ON here so we can test on the Vercel **preview**. Production untouched.

## What to test (use a throwaway test sheet)
1. Open a **test spreadsheet** in two browser windows (normal + incognito, both signed in).
2. **Type in different cells at the same time** (e.g. one window edits A1, the other B2). → Both edits should survive — that's the cell-level merge.
3. **Add a row / add a column** in one → appears in the other.
4. Wait for "saved", **hard-refresh** both → all edits persist.
5. Confirm the **online count / cursors** are correct (the presence fix from documents applies here too).

## Architecture
Mirrors documents: the DB holds the canonical Yjs state; the sheet loads it deterministically on open (never gated on the connection). Cells are stored in a Yjs map keyed by `rowId::col`, so different cells merge independently.

- `src/lib/sheet-crdt.ts` — the cell-level model
- `sheetContent.yjsState` column + `seedSheetYjsStateIfAbsent` atomic guard
- deterministic load + granular publish + remote-merge reconstruction

## DB step required first
Run in the Supabase SQL editor (adds the column; non-destructive):
```sql
ALTER TABLE "safe-cities-project-management-v2_sheet_content"
    ADD COLUMN IF NOT EXISTS "yjsState" text;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)